### PR TITLE
비대칭키 생성 및 저장, 서버 연결시 전송

### DIFF
--- a/chat_client/MyRSA.cpp
+++ b/chat_client/MyRSA.cpp
@@ -1,0 +1,79 @@
+#include "MyRSA.h"
+#include <openssl/err.h>
+
+MyRSA::MyRSA(const std::string& public_key_file) {
+    FILE* pub_file = fopen(public_key_file.c_str(), "r");
+    if (!pub_file) {
+        throw std::runtime_error("Unable to open public key file");
+    }
+    mRsaKey = PEM_read_PUBKEY(pub_file, NULL, NULL, NULL);
+    fclose(pub_file);
+    if (!mRsaKey) {
+        throw std::runtime_error("Unable to read public key");
+    }
+}
+
+MyRSA::~MyRSA() {
+    EVP_PKEY_free(mRsaKey);
+}
+
+void MyRSA::handleErrors() {
+    ERR_print_errors_fp(stderr);
+    abort();
+}
+
+void MyRSA::encrypt(const unsigned char* plaintext, unsigned char* encrypted, size_t& encrypted_len) {
+    EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(mRsaKey, NULL);
+    if (!ctx) handleErrors();
+
+    if (EVP_PKEY_encrypt_init(ctx) <= 0) handleErrors();
+    if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0) handleErrors();
+
+    // Calculate buffer length
+    if (EVP_PKEY_encrypt(ctx, NULL, &encrypted_len, plaintext, strlen((const char*)plaintext)) <= 0) handleErrors();
+
+    // Encrypt the message
+    if (EVP_PKEY_encrypt(ctx, encrypted, &encrypted_len, plaintext, strlen((const char*)plaintext)) <= 0) handleErrors();
+
+    EVP_PKEY_CTX_free(ctx);
+}
+
+void MyRSA::decrypt(const unsigned char* encrypted, size_t encrypted_len, unsigned char* decrypted, size_t& decrypted_len) {
+    EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(mRsaKey, NULL);
+    if (!ctx) handleErrors();
+
+    if (EVP_PKEY_decrypt_init(ctx) <= 0) handleErrors();
+    if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0) handleErrors();
+
+    if (EVP_PKEY_decrypt(ctx, NULL, &decrypted_len, encrypted, encrypted_len) <= 0) handleErrors();
+    if (EVP_PKEY_decrypt(ctx, decrypted, &decrypted_len, encrypted, encrypted_len) <= 0) handleErrors();
+
+    EVP_PKEY_CTX_free(ctx);
+}
+
+EVP_PKEY* MyRSA::create_RSA_keypair() {
+	EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	if (!ctx) handleErrors();
+
+	if (EVP_PKEY_keygen_init(ctx) <= 0) handleErrors();
+	
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 2048) <= 0) handleErrors();
+
+	EVP_PKEY* keypair = NULL;
+	if (EVP_PKEY_keygen(ctx, &keypair) <= 0) handleErrors();
+
+	EVP_PKEY_CTX_free(ctx);
+	return keypair;
+}
+
+void MyRSA::save_keys(EVP_PKEY* keypair) {
+	// Save private key
+	FILE* priv_file = fopen("private.pem", "w");
+	PEM_write_PrivateKey(priv_file, keypair, NULL, NULL, 0, NULL, NULL);
+	fclose(priv_file);
+
+	// Save public key
+	FILE* pub_file = fopen("public.pem", "w");
+	PEM_write_PUBKEY(pub_file, keypair);
+	fclose(pub_file);
+}

--- a/chat_client/MyRSA.h
+++ b/chat_client/MyRSA.h
@@ -1,0 +1,26 @@
+#ifndef RSA_H
+#define RSA_H
+
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <string>
+
+class MyRSA {
+public:
+    MyRSA(const std::string& public_key_file);
+    ~MyRSA();
+
+    // 암호화 및 복호화
+    void encrypt(const unsigned char* plaintext, unsigned char* encrypted, size_t& encrypted_len);
+    void decrypt(const unsigned char* encrypted, size_t encrypted_len, unsigned char* decrypted, size_t& decrypted_len);
+
+    // RSA 키페어 생성 및 저장
+	static EVP_PKEY* create_RSA_keypair();
+	static void save_keys(EVP_PKEY* keypair);
+
+private:
+    EVP_PKEY* mRsaKey;
+    static void handleErrors();
+};
+
+#endif // RSA_H


### PR DESCRIPTION
## 비대칭키 암호화를 위한 작업
- 서버 연결(connect)시 서버의 공개키를 받는다
- 클라이언트의 비대칭키 페어를 만들고
- 클라이언트의 공개키를 서버에 전송한다